### PR TITLE
Create a "triage" system using hashes to avoid doubles

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -17,7 +17,7 @@ easy_admin:
 
             - label: 'admin.menu.actions'
             - { icon: upload, label: "admin.menu.import_operations", route: import_operations }
-            - { icon: sync, label: "admin.menu.sync_operations", route: sync_operations_tags }
+            - { icon: sync, label: "admin.menu.sync_operations", route: sync_operations }
 
     entities:
         TagRule:

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -6,16 +6,18 @@ easy_admin:
 
     design:
         menu:
-            - { icon: chart-bar, label: "Analytics", route: analytics, default: true }
-            - { icon: money-check, entity: Operation }
+            - label: 'admin.menu.account_operations'
+            - { icon: chart-bar, label: "admin.menu.analytics", route: analytics, default: true }
+            - { icon: money-check, label: "admin.menu.operations", entity: Operation }
+            - { icon: box-open, label: "admin.menu.triage", entity: Triage }
 
-            - label: ''
-            - { icon: ruler-vertical, entity: TagRule }
-            - { icon: tags, entity: Tag }
+            - label: 'admin.menu.tags'
+            - { icon: ruler-vertical, label: "admin.menu.tag_rules", entity: TagRule }
+            - { icon: tags, label: "admin.menu.tags", entity: Tag }
 
-            - label: ''
-            - { icon: upload, label: "Import operations", route: import_operations }
-            - { icon: sync, label: "Sync operations", route: apply_rules }
+            - label: 'admin.menu.actions'
+            - { icon: upload, label: "admin.menu.import_operations", route: import_operations }
+            - { icon: sync, label: "admin.menu.sync_operations", route: apply_rules }
 
     entities:
         TagRule:
@@ -41,7 +43,7 @@ easy_admin:
 
         Operation:
             class: App\Entity\Operation
-            label: Operations
+            label: admin.operations.title
             controller: App\Admin\AdminOperationController
             list:
                 actions:
@@ -54,15 +56,58 @@ easy_admin:
                       type: App\Form\Filter\OperationMonthFilterType
                     - tags
                 fields:
-                    - id
-                    - operationDate
-                    - type
-                    - details
+                    - property: id
+                      label: 'admin.operations.fields.id'
+                    - property: operationDate
+                      label: 'admin.operations.fields.operationDate'
+                    - property: type
+                      label: 'admin.operations.fields.type'
+                    - property: details
+                      label: 'admin.operations.fields.details'
                     - property: amount
+                      label: 'admin.operations.fields.amount'
                       type: float
                     - property: tags
+                      label: 'admin.operations.fields.tags'
                       template: easy_admin/field_with_tags.html.twig
 
+        Triage:
+            class: App\Entity\Operation
+            label: admin.triage.title
+            list:
+                actions:
+                    - show
+                    - '-new'
+                    - '-search'
+                    - '-delete'
+                dql_filter: |
+                    entity.state = 'pending'
+                fields:
+                    - property: id
+                      label: 'admin.operations.fields.id'
+                    - property: operationDate
+                      label: 'admin.operations.fields.operationDate'
+                    - property: type
+                      label: 'admin.operations.fields.type'
+                    - property: details
+                      label: 'admin.operations.fields.details'
+                    - property: amount
+                      label: 'admin.operations.fields.amount'
+                      type: float
+            edit:
+                fields:
+                    - property: operationDate
+                      type_options:
+                          widget: single_text
+                          disabled: true
+                    - property: type
+                      type_options:
+                          disabled: true
+                    - property: details
+                    - property: amount
+                      type: number
+                      type_options:
+                          disabled: true
         Tag:
             class: App\Entity\Tag
             label: Tags

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -17,7 +17,7 @@ easy_admin:
 
             - label: 'admin.menu.actions'
             - { icon: upload, label: "admin.menu.import_operations", route: import_operations }
-            - { icon: sync, label: "admin.menu.sync_operations", route: apply_rules }
+            - { icon: sync, label: "admin.menu.sync_operations", route: sync_operations_tags }
 
     entities:
         TagRule:

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -6,17 +6,16 @@ easy_admin:
 
     design:
         menu:
-            - { icon: home, label: "Admin home", route: easyadmin }
-            - { icon: upload, label: "Import operations", route: import_operations }
-            - { icon: sync, label: "Sync operations", route: apply_rules }
-
-            - label: ''
+            - { icon: chart-bar, label: "Analytics", route: analytics, default: true }
             - { icon: money-check, entity: Operation }
-            - { icon: chart-bar, label: "Analytics", route: analytics }
 
             - label: ''
             - { icon: ruler-vertical, entity: TagRule }
             - { icon: tags, entity: Tag }
+
+            - label: ''
+            - { icon: upload, label: "Import operations", route: import_operations }
+            - { icon: sync, label: "Sync operations", route: apply_rules }
 
     entities:
         TagRule:

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -52,6 +52,7 @@ easy_admin:
                 filters:
                     - property: 'operationDate'
                       type: App\Form\Filter\OperationMonthFilterType
+                    - tags
                 fields:
                     - id
                     - operationDate

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -74,14 +74,16 @@ easy_admin:
         Triage:
             class: App\Entity\Operation
             label: admin.triage.title
+            controller: App\Admin\AdminTriageController
+            templates:
+                list: easy_admin/Triage/list.html.twig
             list:
                 actions:
-                    - show
+                    - '-show'
                     - '-new'
                     - '-search'
-                    - '-delete'
                 dql_filter: |
-                    entity.state = 'pending'
+                    entity.state = 'pending_triage'
                 fields:
                     - property: id
                       label: 'admin.operations.fields.id'
@@ -95,19 +97,14 @@ easy_admin:
                       label: 'admin.operations.fields.amount'
                       type: float
             edit:
+                actions:
+                    - '-delete'
                 fields:
-                    - property: operationDate
-                      type_options:
-                          widget: single_text
-                          disabled: true
-                    - property: type
-                      type_options:
-                          disabled: true
-                    - property: details
-                    - property: amount
-                      type: number
-                      type_options:
-                          disabled: true
+                    - operationDate
+                    - type
+                    - amount
+                    - initialDetails
+                    - details
         Tag:
             class: App\Entity\Tag
             label: Tags

--- a/src/Admin/AdminOperationController.php
+++ b/src/Admin/AdminOperationController.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace App\Admin;
 
+use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController;
 
 class AdminOperationController extends EasyAdminController
 {
-    protected function createListQueryBuilder($entityClass, $sortDirection, $sortField = null, $dqlFilter = null)
+    protected function createListQueryBuilder($entityClass, $sortDirection, $sortField = null, $dqlFilter = null): QueryBuilder
     {
         $qb = parent::createListQueryBuilder($entityClass, $sortDirection, $sortField, $dqlFilter);
 

--- a/src/Admin/AdminTriageController.php
+++ b/src/Admin/AdminTriageController.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Compotes package.
+ *
+ * (c) Alex "Pierstoval" Rock <pierstoval@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Admin;
+
+use App\Entity\Operation;
+use App\Form\DTO\Triage;
+use App\Form\Type\TriageType;
+use App\Repository\OperationRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController;
+use InvalidArgumentException;
+use Symfony\Component\Form\FormInterface;
+
+class AdminTriageController extends EasyAdminController
+{
+    private OperationRepository $operationRepository;
+
+    public function __construct(OperationRepository $operationRepository)
+    {
+        $this->operationRepository = $operationRepository;
+    }
+
+    /** @param Operation $entity */
+    protected function createEntityFormBuilder($entity, $view)
+    {
+        if ('edit' !== $view) {
+            throw new InvalidArgumentException('Only edit view is supported.');
+        }
+
+        $dto = Triage::fromOperation($entity);
+
+        $formOptions = $this->executeDynamicMethod('get<EntityName>EntityFormOptions', [$dto, $view]);
+
+        return $this->get('form.factory')->createNamedBuilder(
+            \mb_strtolower($this->entity['name']),
+            TriageType::class,
+            $dto,
+            $formOptions
+        );
+    }
+
+    /** @param Operation $entity */
+    protected function updateEntity($entity, FormInterface $form = null)
+    {
+        if (!$form) {
+            throw new \RuntimeException('Form must be injected by EasyAdmin. Did you mess up something?');
+        }
+
+        /** @var Triage $dto */
+        $dto = $form->getData();
+
+        if (!$dto->hasChanged()) {
+            return;
+        }
+
+        $previousHash = $entity->getHash();
+
+        $entity->updateFromTriage($dto);
+        $this->em->persist($entity);
+
+        $this->endTriage($entity->getId(), $previousHash);
+
+        $this->em->flush();
+    }
+
+    /** @param Operation $entity */
+    protected function removeEntity($entity): void
+    {
+        $previousHash = $entity->getHash();
+
+        $this->em->remove($entity);
+
+        $this->endTriage($entity->getId(), $previousHash);
+
+        $this->em->flush();
+    }
+
+    private function endTriage(int $baseOperationId, string $previousHash): void
+    {
+        $operations = $this->operationRepository->findToEndTriage($baseOperationId, $previousHash);
+
+        if (\count($operations) === 1) {
+            $operations[0]->triageDone();
+            $this->em->persist($operations[0]);
+        }
+    }
+}

--- a/src/Admin/AdminTriageController.php
+++ b/src/Admin/AdminTriageController.php
@@ -19,6 +19,7 @@ use App\Form\Type\TriageType;
 use App\Repository\OperationRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController;
 use InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\Form\FormInterface;
 
 class AdminTriageController extends EasyAdminController
@@ -50,10 +51,10 @@ class AdminTriageController extends EasyAdminController
     }
 
     /** @param Operation $entity */
-    protected function updateEntity($entity, FormInterface $form = null)
+    protected function updateEntity($entity, FormInterface $form = null): void
     {
         if (!$form) {
-            throw new \RuntimeException('Form must be injected by EasyAdmin. Did you mess up something?');
+            throw new RuntimeException('Form must be injected by EasyAdmin. Did you mess up something?');
         }
 
         /** @var Triage $dto */
@@ -89,7 +90,7 @@ class AdminTriageController extends EasyAdminController
     {
         $operations = $this->operationRepository->findToEndTriage($baseOperationId, $previousHash);
 
-        if (\count($operations) === 1) {
+        if (1 === \count($operations)) {
             $operations[0]->triageDone();
             $this->em->persist($operations[0]);
         }

--- a/src/Controller/AnalyticsController.php
+++ b/src/Controller/AnalyticsController.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\DTO\AnalyticsFilters;
+use App\Form\DTO\AnalyticsFilters;
 use App\Form\Type\AnalyticsFiltersType;
 use App\Highcharts\Chart\MonthlyBalanceChart;
 use App\Highcharts\Chart\TagAmountChart;

--- a/src/Controller/ImportOperationsController.php
+++ b/src/Controller/ImportOperationsController.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\DTO\ImportOperations;
+use App\Form\DTO\ImportOperations;
 use App\Form\Type\ImportOperationsType;
 use App\Model\ImportOptions;
 use App\Operations\OperationsImporter;

--- a/src/Controller/SyncOperationsTagsController.php
+++ b/src/Controller/SyncOperationsTagsController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class ApplyTagRulesController
+class SyncOperationsTagsController
 {
     private OperationTagsSynchronizer $synchronizer;
     private UrlGeneratorInterface $router;
@@ -32,7 +32,7 @@ class ApplyTagRulesController
     }
 
     /**
-     * @Route("/admin/apply-rules", name="apply_rules", methods={"GET"})
+     * @Route("/admin/sync-operations-tags", name="sync_operations_tags", methods={"GET"})
      */
     public function __invoke(Session $session): Response
     {

--- a/src/DTO/AnalyticsFilters.php
+++ b/src/DTO/AnalyticsFilters.php
@@ -58,7 +58,7 @@ class AnalyticsFilters
                     return;
                 case DateRanges::LAST_WEEK:
                     // Last-last sunday
-                    $this->startDate = new DateTimeImmutable('-'.(\date('w') + 7).' days 00:00:00');
+                    $this->startDate = new DateTimeImmutable('-'.((string) ((int) \date('w') + 7)).' days 00:00:00');
 
                     return;
                 case DateRanges::THIS_MONTH:

--- a/src/DataFixtures/OperationFixtures.php
+++ b/src/DataFixtures/OperationFixtures.php
@@ -34,6 +34,15 @@ class OperationFixtures extends AbstractFixture implements ORMFixtureInterface
                 'typeDisplay' => 'Example display type',
                 'details' => 'THIS IS JUST AN EXAMPLE',
                 'amountInCents' => 25000,
+                'hash' => function (Operation $operation) {
+                    return Operation::computeHash(
+                        $operation->getType(),
+                        $operation->getTypeDisplay(),
+                        $operation->getDetails(),
+                        $operation->getOperationDate(),
+                        $operation->getAmountInCents()
+                    );
+                },
             ],
         ];
     }

--- a/src/Entity/Operation.php
+++ b/src/Entity/Operation.php
@@ -21,6 +21,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\OperationRepository")
@@ -234,7 +235,7 @@ class Operation
     public function updateFromTriage(Triage $dto): void
     {
         if (!$this->isPendingTriage()) {
-            throw new \LogicException('Cannot update an operation after triage if operation itself is not pending triage.');
+            throw new LogicException('Cannot update an operation after triage if operation itself is not pending triage.');
         }
 
         $this->details = $dto->details;
@@ -262,7 +263,7 @@ class Operation
 
     private function isPendingTriage(): bool
     {
-        return $this->state === self::STATE_PENDING_TRIAGE;
+        return self::STATE_PENDING_TRIAGE === $this->state;
     }
 
     private function recomputeHash(): void

--- a/src/Entity/Operation.php
+++ b/src/Entity/Operation.php
@@ -35,6 +35,11 @@ class Operation
     private $id;
 
     /**
+     * @ORM\Column(name="hash", type="string")
+     */
+    private $hash;
+
+    /**
      * @var DateTimeImmutable
      *
      * @ORM\Column(name="operation_date", type="datetime_immutable")
@@ -116,6 +121,14 @@ class Operation
 
         $self->amountInCents = (int) $amount;
 
+        $self->hash = self::computeHash(
+            $self->getType(),
+            $self->getTypeDisplay(),
+            $self->getDetails(),
+            $self->getOperationDate(),
+            $self->getAmountInCents()
+        );
+
         return $self;
     }
 
@@ -132,6 +145,11 @@ class Operation
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getHash(): string
+    {
+        return $this->hash;
     }
 
     public function getTypeDisplay(): string
@@ -186,6 +204,25 @@ class Operation
         }
 
         return $addedTags;
+    }
+
+    public static function computeHash(
+        string $type,
+        string $typeDisplay,
+        string $details,
+        \DateTimeInterface $operationDate,
+        int $amountInCents
+    ): string
+    {
+        $str =
+            $type.
+            '_'.$typeDisplay.
+            '_'.$details.
+            '_'.$operationDate->format('Y-m-d_H:i:s').
+            '_'.$amountInCents
+        ;
+
+        return \hash('sha512', $str);
     }
 
     private function addTag(Tag $tag): void

--- a/src/Entity/Operation.php
+++ b/src/Entity/Operation.php
@@ -15,6 +15,7 @@ namespace App\Entity;
 
 use App\Model\ImportOptions;
 use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -27,17 +28,15 @@ use InvalidArgumentException;
  */
 class Operation
 {
+    public const STATE_OK = 'ok';
+    public const STATE_PENDING = 'pending';
+
     /**
      * @ORM\Id()
      * @ORM\GeneratedValue()
      * @ORM\Column(name="id", type="integer")
      */
     private $id;
-
-    /**
-     * @ORM\Column(name="hash", type="string")
-     */
-    private $hash;
 
     /**
      * @var DateTimeImmutable
@@ -76,6 +75,16 @@ class Operation
      * @ORM\Column(name="amount_in_cents", type="integer")
      */
     private $amountInCents;
+
+    /**
+     * @ORM\Column(name="hash", type="string")
+     */
+    private $hash;
+
+    /**
+     * @ORM\Column(name="state", type="string", options={"default" = "pending"})
+     */
+    private $state = self::STATE_PENDING;
 
     /**
      * @ORM\ManyToMany(targetEntity="App\Entity\Tag", cascade={"persist"})
@@ -172,6 +181,11 @@ class Operation
         return $this->amountInCents / 100;
     }
 
+    public function getState(): string
+    {
+        return $this->state;
+    }
+
     /**
      * @return Collection|Tag[]
      */
@@ -210,10 +224,9 @@ class Operation
         string $type,
         string $typeDisplay,
         string $details,
-        \DateTimeInterface $operationDate,
+        DateTimeInterface $operationDate,
         int $amountInCents
-    ): string
-    {
+    ): string {
         $str =
             $type.
             '_'.$typeDisplay.

--- a/src/Form/DTO/AnalyticsFilters.php
+++ b/src/Form/DTO/AnalyticsFilters.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace App\DTO;
+namespace App\Form\DTO;
 
 use App\Model\DateRanges;
 use DateTimeImmutable;

--- a/src/Form/DTO/ImportOperations.php
+++ b/src/Form/DTO/ImportOperations.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace App\DTO;
+namespace App\Form\DTO;
 
 use App\Model\ImportOptions;
 use Symfony\Component\HttpFoundation\File\UploadedFile;

--- a/src/Form/DTO/Triage.php
+++ b/src/Form/DTO/Triage.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Compotes package.
+ *
+ * (c) Alex "Pierstoval" Rock <pierstoval@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form\DTO;
+
+use App\Entity\Operation;
+use DateTimeInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * @Assert\Callback(callback="validate")
+ */
+class Triage
+{
+    /**
+     * @Assert\NotBlank()
+     */
+    public ?string $details;
+
+    private DateTimeInterface $operationDate;
+    private string $type;
+    private float $amount;
+    private string $initialDetails;
+
+    private function __construct()
+    {
+    }
+
+    public static function fromOperation(Operation $operation): self
+    {
+        $self = new self();
+
+        $self->operationDate = $operation->getOperationDate();
+        $self->type = $operation->getType();
+        $self->amount = $operation->getAmount();
+        $self->initialDetails = $operation->getDetails();
+        $self->details = $operation->getDetails();
+
+        return $self;
+    }
+
+    public function validate(ExecutionContextInterface $context): void
+    {
+        if (false === \strpos($this->details, $this->initialDetails)) {
+            $context
+                ->buildViolation('admin.triage.validators.initials_details_must_not_be_lost')
+                ->setTranslationDomain('messages')
+                ->atPath('details')
+                ->addViolation()
+            ;
+        }
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getOperationDate(): DateTimeInterface
+    {
+        return $this->operationDate;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function getInitialDetails(): string
+    {
+        return $this->initialDetails;
+    }
+
+    public function hasChanged(): bool
+    {
+        return $this->details !== $this->initialDetails;
+    }
+}

--- a/src/Form/Type/AnalyticsFiltersType.php
+++ b/src/Form/Type/AnalyticsFiltersType.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace App\Form\Type;
 
-use App\DTO\AnalyticsFilters;
+use App\Form\DTO\AnalyticsFilters;
 use App\Model\DateRanges;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;

--- a/src/Form/Type/ImportOperationsType.php
+++ b/src/Form/Type/ImportOperationsType.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace App\Form\Type;
 
-use App\DTO\ImportOperations;
+use App\Form\DTO\ImportOperations;
 use App\Model\ImportOptions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;

--- a/src/Form/Type/TriageType.php
+++ b/src/Form/Type/TriageType.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Compotes package.
+ *
+ * (c) Alex "Pierstoval" Rock <pierstoval@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form\Type;
+
+use App\Form\DTO\Triage;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TriageType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('operationDate', DateTimeType::class, [
+                'widget' => 'single_text',
+                'disabled' => true,
+                'required' => false,
+            ])
+            ->add('type', TextType::class, [
+                'disabled' => true,
+                'required' => false,
+            ])
+            ->add('amount', TextType::class, [
+                'disabled' => true,
+                'required' => false,
+            ])
+            ->add('initialDetails', TextareaType::class, [
+                'disabled' => true,
+                'required' => false,
+            ])
+            ->add('details', TextareaType::class, [
+                'required' => true,
+            ])
+        ;
+    }
+
+    public function getParent()
+    {
+        return EasyAdminFormType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Triage::class,
+        ]);
+    }
+}

--- a/src/Migrations/Version20200215101535.php
+++ b/src/Migrations/Version20200215101535.php
@@ -2,9 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Compotes package.
+ *
+ * (c) Alex "Pierstoval" Rock <pierstoval@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace DoctrineMigrations;
 
 use App\Entity\Operation;
+use DateTimeImmutable;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -13,24 +23,24 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20200215101535 extends AbstractMigration
 {
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return 'Adds a "hash" to all operations, to uniquely identify them.';
     }
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE operations ADD hash VARCHAR(255) DEFAULT NULL');
 
-        $operations = $this->connection->query(<<<SQL
+        $operations = $this->connection->query(<<<'SQL'
             SELECT id, operation_date, type, type_display, details, amount_in_cents
             FROM operations
         SQL);
         foreach ($operations as $operation) {
-            $this->addSql(<<<SQL
+            $this->addSql(<<<'SQL'
                 UPDATE operations
                 SET hash = :hash
                 WHERE id = :id
@@ -40,19 +50,19 @@ final class Version20200215101535 extends AbstractMigration
                     $operation['type'],
                     $operation['type_display'],
                     $operation['details'],
-                    new \DateTimeImmutable($operation['operation_date']),
+                    new DateTimeImmutable($operation['operation_date']),
                     (int) $operation['amount_in_cents']
-                )
+                ),
             ]);
         }
 
         $this->addSql('ALTER TABLE operations CHANGE hash hash VARCHAR(255) NOT NULL');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE operations DROP hash');
     }

--- a/src/Migrations/Version20200215101535.php
+++ b/src/Migrations/Version20200215101535.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Entity\Operation;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200215101535 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Adds a "hash" to all operations, to uniquely identify them.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE operations ADD hash VARCHAR(255) DEFAULT NULL');
+
+        $operations = $this->connection->query(<<<SQL
+            SELECT id, operation_date, type, type_display, details, amount_in_cents
+            FROM operations
+        SQL);
+        foreach ($operations as $operation) {
+            $this->addSql(<<<SQL
+                UPDATE operations
+                SET hash = :hash
+                WHERE id = :id
+            SQL, [
+                'id' => $operation['id'],
+                'hash' => Operation::computeHash(
+                    $operation['type'],
+                    $operation['type_display'],
+                    $operation['details'],
+                    new \DateTimeImmutable($operation['operation_date']),
+                    (int) $operation['amount_in_cents']
+                )
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE operations CHANGE hash hash VARCHAR(255) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE operations DROP hash');
+    }
+}

--- a/src/Migrations/Version20200215215340.php
+++ b/src/Migrations/Version20200215215340.php
@@ -31,7 +31,7 @@ final class Version20200215215340 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE operations ADD state VARCHAR(255) DEFAULT \'pending\' NOT NULL');
+        $this->addSql('ALTER TABLE operations ADD state VARCHAR(255) DEFAULT \'ok\' NOT NULL');
         $this->addSql('UPDATE operations SET state = "ok"');
     }
 

--- a/src/Migrations/Version20200215215340.php
+++ b/src/Migrations/Version20200215215340.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Compotes package.
+ *
+ * (c) Alex "Pierstoval" Rock <pierstoval@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200215215340 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add "state" property to Operation entity';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE operations ADD state VARCHAR(255) DEFAULT \'pending\' NOT NULL');
+        $this->addSql('UPDATE operations SET state = "ok"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE operations DROP state');
+    }
+}

--- a/src/Operations/TriageSynchronizer.php
+++ b/src/Operations/TriageSynchronizer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Compotes package.
+ *
+ * (c) Alex "Pierstoval" Rock <pierstoval@gmail.com>.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Operations;
+
+use App\Repository\OperationRepository;
+use App\Repository\TagRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class TriageSynchronizer
+{
+    private OperationRepository $operationRepository;
+    private TagRepository $tagRepository;
+    private EntityManagerInterface $em;
+
+    public function __construct(
+        OperationRepository $operationRepository,
+        TagRepository $tagRepository,
+        EntityManagerInterface $em
+    ) {
+        $this->operationRepository = $operationRepository;
+        $this->tagRepository = $tagRepository;
+        $this->em = $em;
+    }
+
+    public function syncOperations(): int
+    {
+        $operations = $this->operationRepository->findWithSameHashes();
+
+        foreach ($operations as $operation) {
+            $operation->flagForTriage();
+            $this->em->persist($operation);
+        }
+
+        $this->em->flush();
+
+        return \count($operations);
+    }
+}

--- a/src/Repository/OperationRepository.php
+++ b/src/Repository/OperationRepository.php
@@ -93,7 +93,7 @@ class OperationRepository extends ServiceEntityRepository
                 WHERE operation.hash = :hash
                 AND operation.id != :id
             DQL
-            )
+        )
             ->setParameter('id', $baseOperationId)
             ->setParameter('hash', $previousHash)
             ->getResult()

--- a/templates/easy_admin/Triage/list.html.twig
+++ b/templates/easy_admin/Triage/list.html.twig
@@ -1,0 +1,9 @@
+{% extends '@!EasyAdmin/default/list.html.twig' %}
+
+{% block content_header %}
+    {{ parent() }}
+    <br>
+    <p>
+        {{ 'admin.triage.list_help_message'|trans|raw }}
+    </p>
+{% endblock %}

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -50,7 +50,7 @@ class AdminTest extends WebTestCase
         $this->login($client, 'test-user', ['ROLE_ADMIN']);
         $client->request('GET', '/admin/');
 
-        $this->assertResponseRedirects('/admin/analytics?menuIndex=0&submenuIndex=-1', 302);
+        $this->assertResponseRedirects('/admin/analytics?menuIndex=1&submenuIndex=-1', 302);
         $client->followRedirect();
         $this->assertResponseStatusCodeSame(200);
     }

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -50,7 +50,7 @@ class AdminTest extends WebTestCase
         $this->login($client, 'test-user', ['ROLE_ADMIN']);
         $client->request('GET', '/admin/');
 
-        $this->assertResponseRedirects('/admin/?action=list&entity=TagRule', 302);
+        $this->assertResponseRedirects('/admin/analytics?menuIndex=0&submenuIndex=-1', 302);
         $client->followRedirect();
         $this->assertResponseStatusCodeSame(200);
     }

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1,3 +1,23 @@
+admin.menu.account_operations: Account operations
+admin.menu.tags: Tags
+admin.menu.actions: Actions
+admin.menu.analytics: Analytics
+admin.menu.triage: Triage
+admin.menu.operations: Operations
+admin.menu.tag_rules: Tag rules
+admin.menu.import_operations: Import operations
+admin.menu.sync_operations: Sync operations
+
+admin.operations.title: Bank account operations
+admin.operations.fields.id: Id
+admin.operations.fields.operationDate: Operation date
+admin.operations.fields.type: Type
+admin.operations.fields.details: Details
+admin.operations.fields.amount: Amount
+admin.operations.fields.tags: Tags
+
+admin.triage.title: 'Triage of potential operations duplicates'
+
 import_operations.form.submit: Import file
 import_operations.validators.invalid_file_name: Filename "{{ file_name }}" does not respect the "{year}-{month}.csv" format.
 import_operations.validators.invalid_line_headers: 'CSV headers order is not valid. Available fields: {{ headers }}'

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -16,6 +16,10 @@ admin.operations.fields.details: Details
 admin.operations.fields.amount: Amount
 admin.operations.fields.tags: Tags
 
+admin.sync_operations.no_operations_synced: No operation to synchronize.
+admin.sync_operations.success: |
+    Successfully synchronized %synced% operations!
+
 admin.triage.title: 'Triage of potential operations duplicates'
 
 import_operations.form.submit: Import file

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -16,11 +16,41 @@ admin.operations.fields.details: Details
 admin.operations.fields.amount: Amount
 admin.operations.fields.tags: Tags
 
-admin.sync_operations.no_operations_synced: No operation to synchronize.
+admin.sync_operations.no_operations_synced: No operation needs to be synchronized with tag rules for the moment.
 admin.sync_operations.success: |
-    Successfully synchronized %synced% operations!
+    ]-Inf, 0] Noop
+    |{1} Successfully synchronized %count% operation according to tag rules!
+    |[2, +Inf[ Successfully synchronized %count% operations according to tag rules!
+admin.sync_operations.pending_triage: |
+    ]-Inf, 0] Noop
+    |[1, +Inf[ There are %count% operations pending for triage.
 
 admin.triage.title: 'Triage of potential operations duplicates'
+admin.triage.validators.initials_details_must_not_be_lost: |
+    When updating an operation for triage, you must keep the original details and only append or prepend a note
+    to avoid duplicate operations. If this operation is a true duplicate, you can delete it.
+admin.triage.list_help_message: |
+    This page lists the different Operations that <em>seem</em> to be duplicates.
+
+    You have two choices here:
+
+    <ul>
+        <li>
+            If operations are <strong>not</strong> duplicates, you can update the description of one of them <strong>while
+            keeping the initial details</strong> (like, appending or prepending a note to distinguish both operations).
+            <br>
+            The reason you need to keep initial details is to keep the tag rules working for this operation. Else, the
+            operation would possibly stop matching some rules and break the synchronization process.
+            <br>
+            The goal is to make each operation <strong>unique</strong> by having a unique combination of all its fields
+            (labels, details, amount, etc.). And to avoid breaking analytics, only details can be updated.
+        </li>
+        <li>
+            If operations <strong>are</strong> duplicates, you can delete the one(s) you don't want.
+            <br>
+            <strong>Be aware that deleting operations is an irreversible action.</strong>
+        </li>
+    </ul>
 
 import_operations.form.submit: Import file
 import_operations.validators.invalid_file_name: Filename "{{ file_name }}" does not respect the "{year}-{month}.csv" format.


### PR DESCRIPTION
The goal is to be able to detect doubles, and if there are doubles, put them in a `pending` state so that we can make sure that we don't import something twice.

That's a big WIP because a lot must be handled on the user-side to change this.

The goal of these hashes is to **force** the user to manually add a note on the `description` field of operations that have the same hash, in order to recompute the hash and have unique hashes everywhere.

This helps a lot making sure we can import the same files multiple times and have a way to make sure we don't get doubles that might break the entire analytics.